### PR TITLE
Add a nice bootstrap confirmation dialog box

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false
 end
+gem 'data-confirm-modal', github: 'ifad/data-confirm-modal'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/ifad/data-confirm-modal.git
+  revision: ba73f2fccd4451ee2f41f2f6995bff8f7ede3459
+  specs:
+    data-confirm-modal (1.0.2)
+      railties (>= 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -133,6 +140,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootstrap-sass (~> 3.3.0)
   coffee-rails (~> 4.0.0)
+  data-confirm-modal!
   devise (>= 3.2.4)
   jbuilder (~> 1.2)
   jquery-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,5 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .
+//= require data-confirm-modal
 

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -5,6 +5,8 @@
 	<p><%= @place.description %></p>
 	<div class="pull-right">
 		<%= link_to 'Edit', edit_place_path(@place), :class => 'btn btn-primary' %>
-		<%= link_to 'Destroy', place_path(@place), :method => :delete, :data => {:confirm => 'Are you sure you want to delete this?'}, :class => 'btn btn-danger' %>
+		<%= link_to 'Destroy', place_path(@place), :method => :delete, :data => {:confirm => 'Are you sure you want to delete this?', :commit => 'just do it', :cancel => 'nah, I don\'t really wanna'}, :class => 'btn btn-danger' %>
 	</div>
 </div>
+
+


### PR DESCRIPTION
Hey Rob -

Here's how I used the gem to easily add the bootstrap confirmation dialog box instead of a lame regular JavaScript alert box.

---

As a side note, this is a GitHub pull request.  This is how I can show you code that I think you should add to your project.  It allows you to look at the code, you'll see the green code is code that's added and the red is code that's deleted.  The "Files changed" tab will show you the code.

"Commits" will show you a listing of the individual commits I'm trying to send you.  And this tab, the conversation tab you can use to communicate about the change.

If you want to suck in all this code into your project you can by pressing the green merge button.  If you want to take these changes, I would suggest first you remove all of the local changes you've done (a lot of them are the same, because we went through them in office hours together, so crazy conflicts would come up if you committed them):

```
git reset --hard
```

After you press the merge button, you'll have to update your web dev environment to have the latest updates from GitHub and to do that you can run this command:

```
git pull origin master
```

Hope this helps.

Cheers,
Ken
